### PR TITLE
feat: implement message queue system and distributed locking

### DIFF
--- a/backend/src/services/DistributedLockService.ts
+++ b/backend/src/services/DistributedLockService.ts
@@ -1,0 +1,157 @@
+import { createClient, RedisClientType } from 'redis';
+import { randomUUID } from 'crypto';
+import { logger } from '@/utils/logger';
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+const DEFAULT_TTL_MS = 10_000;
+const RENEWAL_INTERVAL_MS = 5_000;
+
+export interface LockHandle {
+  key: string;
+  token: string;
+  stopRenewal: () => void;
+}
+
+export class DistributedLockService {
+  private client: RedisClientType;
+  private connected = false;
+
+  constructor() {
+    this.client = createClient({ url: REDIS_URL }) as RedisClientType;
+    this.client.on('error', (err) => logger.error('DistributedLockService Redis error:', err));
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (!this.connected) {
+      await this.client.connect();
+      this.connected = true;
+    }
+  }
+
+  /**
+   * Acquire a distributed lock.
+   * Returns a LockHandle on success, or null if the lock is already held.
+   *
+   * @param key      - Unique resource identifier
+   * @param ttlMs    - Lock TTL in milliseconds (auto-expires to prevent deadlocks)
+   * @param renewalMs - How often to renew the lock while held (0 = no renewal)
+   */
+  async acquire(
+    key: string,
+    ttlMs = DEFAULT_TTL_MS,
+    renewalMs = RENEWAL_INTERVAL_MS
+  ): Promise<LockHandle | null> {
+    await this.ensureConnected();
+
+    const token = randomUUID();
+    const lockKey = `lock:${key}`;
+
+    // SET key token NX PX ttl — atomic acquire
+    const result = await this.client.set(lockKey, token, { NX: true, PX: ttlMs });
+    if (result !== 'OK') {
+      logger.debug(`Lock "${key}" already held, acquire failed`);
+      return null;
+    }
+
+    logger.info(`Lock "${key}" acquired (token: ${token}, ttl: ${ttlMs}ms)`);
+
+    let renewalTimer: NodeJS.Timeout | null = null;
+
+    if (renewalMs > 0) {
+      renewalTimer = setInterval(async () => {
+        try {
+          await this.renew(lockKey, token, ttlMs);
+        } catch (err) {
+          logger.error(`Lock renewal failed for "${key}":`, err);
+        }
+      }, renewalMs);
+    }
+
+    const stopRenewal = () => {
+      if (renewalTimer) {
+        clearInterval(renewalTimer);
+        renewalTimer = null;
+      }
+    };
+
+    return { key: lockKey, token, stopRenewal };
+  }
+
+  /**
+   * Release a lock. Only the owner (matching token) can release it.
+   */
+  async release(handle: LockHandle): Promise<boolean> {
+    await this.ensureConnected();
+    handle.stopRenewal();
+
+    // Lua script ensures atomic check-and-delete
+    const script = `
+      if redis.call("GET", KEYS[1]) == ARGV[1] then
+        return redis.call("DEL", KEYS[1])
+      else
+        return 0
+      end
+    `;
+    const result = await this.client.eval(script, { keys: [handle.key], arguments: [handle.token] });
+    const released = result === 1;
+    if (released) {
+      logger.info(`Lock "${handle.key}" released`);
+    } else {
+      logger.warn(`Lock "${handle.key}" release failed — token mismatch or already expired`);
+    }
+    return released;
+  }
+
+  /**
+   * Renew the TTL of a held lock (only if the token still matches).
+   */
+  private async renew(lockKey: string, token: string, ttlMs: number): Promise<boolean> {
+    const script = `
+      if redis.call("GET", KEYS[1]) == ARGV[1] then
+        return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+      else
+        return 0
+      end
+    `;
+    const result = await this.client.eval(script, {
+      keys: [lockKey],
+      arguments: [token, String(ttlMs)],
+    });
+    const renewed = result === 1;
+    if (renewed) {
+      logger.debug(`Lock "${lockKey}" renewed for ${ttlMs}ms`);
+    } else {
+      logger.warn(`Lock "${lockKey}" renewal failed — lock may have expired`);
+    }
+    return renewed;
+  }
+
+  /**
+   * Convenience wrapper: acquire → run → release.
+   * Throws if the lock cannot be acquired.
+   */
+  async withLock<T>(
+    key: string,
+    fn: () => Promise<T>,
+    ttlMs = DEFAULT_TTL_MS
+  ): Promise<T> {
+    const handle = await this.acquire(key, ttlMs);
+    if (!handle) {
+      throw new Error(`Could not acquire lock for "${key}" — resource is busy`);
+    }
+    try {
+      return await fn();
+    } finally {
+      await this.release(handle);
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.connected) {
+      await this.client.disconnect();
+      this.connected = false;
+    }
+  }
+}
+
+export const distributedLockService = new DistributedLockService();

--- a/backend/src/services/MessageQueueService.ts
+++ b/backend/src/services/MessageQueueService.ts
@@ -1,0 +1,98 @@
+import Bull, { Queue, Job, JobOptions } from 'bull';
+import { logger } from '@/utils/logger';
+
+export type QueueName = 'transactions' | 'notifications' | 'events';
+
+export interface MessageJob<T = unknown> {
+  type: string;
+  payload: T;
+  timestamp: number;
+}
+
+const DEAD_LETTER_QUEUE = 'dead-letter';
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+
+const defaultJobOptions: JobOptions = {
+  attempts: 3,
+  backoff: { type: 'exponential', delay: 2000 },
+  removeOnComplete: 100,
+  removeOnFail: false,
+};
+
+export class MessageQueueService {
+  private queues = new Map<string, Queue>();
+
+  private getQueue(name: string): Queue {
+    if (!this.queues.has(name)) {
+      const queue = new Bull(name, REDIS_URL);
+      queue.on('failed', (job, err) => {
+        logger.error(`Job ${job.id} in queue "${name}" failed: ${err.message}`);
+        if (job.attemptsMade >= (job.opts.attempts ?? 1)) {
+          this.sendToDeadLetter(name, job).catch((e) =>
+            logger.error('Dead letter enqueue error:', e)
+          );
+        }
+      });
+      queue.on('completed', (job) =>
+        logger.info(`Job ${job.id} in queue "${name}" completed`)
+      );
+      this.queues.set(name, queue);
+    }
+    return this.queues.get(name)!;
+  }
+
+  private async sendToDeadLetter(originQueue: string, job: Job): Promise<void> {
+    const dlq = this.getQueue(DEAD_LETTER_QUEUE);
+    await dlq.add({ originQueue, jobId: job.id, data: job.data, failedReason: job.failedReason });
+    logger.warn(`Job ${job.id} from "${originQueue}" moved to dead-letter queue`);
+  }
+
+  /**
+   * Publish a message to a named queue.
+   */
+  async publish<T>(
+    queueName: QueueName,
+    message: MessageJob<T>,
+    options: JobOptions = {}
+  ): Promise<Job<MessageJob<T>>> {
+    const queue = this.getQueue(queueName);
+    const job = await queue.add(message, { ...defaultJobOptions, ...options });
+    logger.info(`Published job ${job.id} to queue "${queueName}" (type: ${message.type})`);
+    return job;
+  }
+
+  /**
+   * Register a processor for a named queue.
+   */
+  subscribe<T>(
+    queueName: QueueName,
+    processor: (job: Job<MessageJob<T>>) => Promise<void>,
+    concurrency = 1
+  ): void {
+    const queue = this.getQueue(queueName);
+    queue.process(concurrency, processor);
+    logger.info(`Subscribed processor to queue "${queueName}" (concurrency: ${concurrency})`);
+  }
+
+  /**
+   * Get queue metrics for monitoring.
+   */
+  async getMetrics(queueName: QueueName) {
+    const queue = this.getQueue(queueName);
+    const [waiting, active, completed, failed, delayed] = await Promise.all([
+      queue.getWaitingCount(),
+      queue.getActiveCount(),
+      queue.getCompletedCount(),
+      queue.getFailedCount(),
+      queue.getDelayedCount(),
+    ]);
+    return { queueName, waiting, active, completed, failed, delayed };
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([...this.queues.values()].map((q) => q.close()));
+    logger.info('All message queues closed');
+  }
+}
+
+export const messageQueueService = new MessageQueueService();


### PR DESCRIPTION
## Summary

Resolves both issues assigned to @Xuccessor by adding two new backend services.

---

### Issue #49 — Message Queue System

**File:** `backend/src/services/MessageQueueService.ts`

- Bull-based async message queue (Redis-backed, already a project dependency)
- Named queues: `transactions`, `notifications`, `events`
- Dead letter queue: failed jobs (after all retries) are moved to `dead-letter` queue for inspection
- Configurable retries with exponential backoff (default: 3 attempts)
- `publish()` / `subscribe()` API with concurrency control
- `getMetrics()` for queue depth monitoring

### Issue #50 — Distributed Locking Mechanism

**File:** `backend/src/services/DistributedLockService.ts`

- Redis `SET key token NX PX ttl` for atomic lock acquisition
- Automatic TTL renewal via `setInterval` to prevent expiry under long-running operations
- Lua-script atomic release (check token + delete in one round-trip, prevents releasing another owner's lock)
- `withLock(key, fn)` convenience wrapper for critical sections
- Configurable TTL and renewal interval

---

Closes #49
Closes #50